### PR TITLE
team and ally damage limiters added to weapon_area_damage_gadget

### DIFF
--- a/luarules/configs/area_damage_defs.lua
+++ b/luarules/configs/area_damage_defs.lua
@@ -4,8 +4,8 @@ local DAMAGE_PERIOD = 2 -- how often damage is applied
 
 local weapons = {
 	tllacid_acidrain_rocket = { radius = 400, damage = 100, duration = 625, rangeFall = 0.6, timeFall = 0.5},
-	armsonic_sonic_cannon = { radius = 95, damage = 200, duration = 120, rangeFall = 0.25, timeFall = 0.8},
-	tllriot_tllriot_cannon = { radius = 80, damage = 250, duration = 45, rangeFall = 0.25, timeFall = 0.6},
+	armsonic_sonic_cannon = { radius = 95, damage = 200, duration = 120, rangeFall = 0.25, timeFall = 0.8, allyScale = 0.5 },
+	tllriot_tllriot_cannon = { radius = 80, damage = 250, duration = 45, rangeFall = 0.25, timeFall = 0.6, allyScale = 0.5 },
 	thermite_mine = { radius = 64, damage = 750, duration = 130, rangeFall = 0.25, timeFall = 0.6}
 
 }

--- a/luarules/gadgets/weapon_area_damage.lua
+++ b/luarules/gadgets/weapon_area_damage.lua
@@ -20,6 +20,8 @@ local DAMAGE_PERIOD ,weaponInfo = include("LuaRules/Configs/area_damage_defs.lua
 local SpAddUnitDamage = Spring.AddUnitDamage
 local SpGetUnitsInSphere = Spring.GetUnitsInSphere
 local SpGetUnitPosition = Spring.GetUnitPosition
+local SpGetUnitTeam = Spring.GetUnitTeam
+local SpGetUnitAllyTeam = Spring.GetUnitAllyTeam
 local sqrt = math.sqrt
 local pairs = pairs
 local ipairs = ipairs
@@ -52,10 +54,23 @@ function gadget:GameFrame(f)
 				for _,u in ipairs(ulist) do
 					local ux, uy, uz = SpGetUnitPosition(u)
 					local damage = w.damage
+					local allyScale = w.allyScale or 1.0
+					local teamScale = w.teamScale or 1.0
 					if w.rangeFall ~= 0 then
 						damage = damage - damage*w.rangeFall*sqrt((ux-w.pos.x)^2 + (uy-w.pos.y)^2 + (uz-w.pos.z)^2)/w.radius
 					end
-					SpAddUnitDamage(u, damage, 0, w.owner, w.id, 0, 0, 0)
+					-- Scale team and allyteam damage
+					if (SpGetUnitTeam(w.id) == SpGetUnitTeam(w.owner)) {
+					   damage = damage * teamScale
+					}
+					if (SpGetUnitAllyTeam(w.id) == SpGetUnitAllyTeam(w.owner)) {
+					   damage = damage * allyScale
+					}
+					
+					-- Avoid damage to self altogether
+					if (w.id != nil and w.owner != nil and w.id != w.owner) {
+					   SpAddUnitDamage(u, damage, 0, w.owner, w.id, 0, 0, 0)
+					}
 				end
 			end
 			w.damage = w.damage - w.timeLoss

--- a/luarules/gadgets/weapon_area_damage.lua
+++ b/luarules/gadgets/weapon_area_damage.lua
@@ -22,6 +22,7 @@ local SpGetUnitsInSphere = Spring.GetUnitsInSphere
 local SpGetUnitPosition = Spring.GetUnitPosition
 local SpGetUnitTeam = Spring.GetUnitTeam
 local SpGetUnitAllyTeam = Spring.GetUnitAllyTeam
+local SpEcho = Spring.Echo
 local sqrt = math.sqrt
 local pairs = pairs
 local ipairs = ipairs
@@ -60,17 +61,17 @@ function gadget:GameFrame(f)
 						damage = damage - damage*w.rangeFall*sqrt((ux-w.pos.x)^2 + (uy-w.pos.y)^2 + (uz-w.pos.z)^2)/w.radius
 					end
 					-- Scale team and allyteam damage
-					if (SpGetUnitTeam(w.id) == SpGetUnitTeam(w.owner)) {
+					if (SpGetUnitTeam(w.id) == SpGetUnitTeam(w.owner)) then
 					   damage = damage * teamScale
-					}
-					if (SpGetUnitAllyTeam(w.id) == SpGetUnitAllyTeam(w.owner)) {
+					end
+					if (SpGetUnitAllyTeam(w.id) == SpGetUnitAllyTeam(w.owner)) then
 					   damage = damage * allyScale
-					}
+					end
 					
 					-- Avoid damage to self altogether
-					if (w.id != nil and w.owner != nil and w.id != w.owner) {
+					if (w.id ~= nil and w.owner ~= nil and w.id ~= w.owner) then
 					   SpAddUnitDamage(u, damage, 0, w.owner, w.id, 0, 0, 0)
-					}
+					end
 				end
 			end
 			w.damage = w.damage - w.timeLoss


### PR DESCRIPTION
This adds multiplier attributes to the weapon_area_damage gadget. Both default to 1.0. 

Area damage always does zero damage to origin unit. The reasoning is that there is already a nonselfdamage attribute for the unit's weapondef.

Also configured a 0.5 ally damage multipler to arm sonic tanks and tll riot tanks. I play tested this lightly, a large clash with peewees will leave the tanks quite bruised, but mostly intact. 

This type of damage is more effective on offense (hitting stationary or peripheral units) than defense (hitting approaching or swarming units). This is because area damage doesn't push back and stun like, say, the levelers do.